### PR TITLE
Define fault types & extend data model

### DIFF
--- a/src/main/java/swarm/messages/DroneState.java
+++ b/src/main/java/swarm/messages/DroneState.java
@@ -1,7 +1,7 @@
 package swarm.messages;
 
 /**
- * Drone lifecycle states for Iteration 2.
+ * Drone lifecycle states.
  */
 public enum DroneState {
     IDLE,
@@ -10,5 +10,6 @@ public enum DroneState {
     DROPPING_AGENT,
     RETURNING,
     REFILLING,
-    FAULT
+    SOFT_FAULT,
+    HARD_FAULT
 }

--- a/src/main/java/swarm/messages/FaultType.java
+++ b/src/main/java/swarm/messages/FaultType.java
@@ -1,0 +1,30 @@
+package swarm.messages;
+
+/**
+ * Types of faults that can be injected into a drone during simulation.
+ *
+ * NONE           no fault (default)
+ * DRONE_STUCK    drone freezes mid-flight (soft fault, recoverable after reset)
+ * NOZZLE_JAMMED  nozzle/bay doors stuck (hard fault, drone permanently offline)
+ * PACKET_LOSS    status messages dropped/corrupted (soft fault)
+ */
+public enum FaultType {
+    NONE(false),
+    DRONE_STUCK(false),
+    NOZZLE_JAMMED(true),
+    PACKET_LOSS(false);
+
+    private final boolean hardFault;
+
+    FaultType(boolean hardFault) {
+        this.hardFault = hardFault;
+    }
+
+    /**
+     * Hard faults permanently disable the drone.
+     * Soft faults are recoverable after a timeout/reset.
+     */
+    public boolean isHardFault() {
+        return hardFault;
+    }
+}

--- a/src/main/java/swarm/messages/FireEvent.java
+++ b/src/main/java/swarm/messages/FireEvent.java
@@ -4,16 +4,22 @@ import java.time.Instant;
 
 /**
  * Produced by FireIncidentSubsystem, consumed by Scheduler.
- * Timestamp is kept as epoch millis to match file inputs easily.
  */
 public record FireEvent(
         long timestampMillis,
         int zoneId,
         EventType type,
-        Severity severity
+        Severity severity,
+        FaultType fault
 ) {
     public Instant timestamp() {
         return Instant.ofEpochMilli(timestampMillis);
     }
-}
 
+    /**
+     * Backward-compatible constructor for events with no fault.
+     */
+    public FireEvent(long timestampMillis, int zoneId, EventType type, Severity severity) {
+        this(timestampMillis, zoneId, type, severity, FaultType.NONE);
+    }
+}

--- a/src/main/java/swarm/subsystems/DroneSubsystem.java
+++ b/src/main/java/swarm/subsystems/DroneSubsystem.java
@@ -5,6 +5,7 @@ import swarm.infra.UDPHelper;
 import swarm.infra.ZoneManager;
 import swarm.main.SimulatorGUI;
 import swarm.messages.DroneState;
+import swarm.messages.FaultType;
 import swarm.messages.Severity;
 import swarm.model.Position;
 
@@ -58,34 +59,34 @@ public class DroneSubsystem implements Runnable {
                     }
 
                     // EN_ROUTE
-                    reportStatus(DroneState.EN_ROUTE, zoneId);
+                    reportStatus(DroneState.EN_ROUTE, zoneId, FaultType.NONE);
                     long flightTime = DroneConfig.travelTimeMillis(currentPosition.distanceTo(target));
                     Thread.sleep(flightTime / 10);
                     currentPosition = target;
 
                     // ARRIVED
-                    reportStatus(DroneState.ARRIVED, zoneId);
+                    reportStatus(DroneState.ARRIVED, zoneId, FaultType.NONE);
 
                     // DROPPING_AGENT
-                    reportStatus(DroneState.DROPPING_AGENT, zoneId);
+                    reportStatus(DroneState.DROPPING_AGENT, zoneId, FaultType.NONE);
                     long dropTime = DroneConfig.dropTimeMillis(severity.litersRequired())
                             + DroneConfig.doorOpenCloseMillis();
                     Thread.sleep(dropTime / 10);
                     currentAgent -= severity.litersRequired();
 
                     // RETURNING
-                    reportStatus(DroneState.RETURNING, zoneId);
+                    reportStatus(DroneState.RETURNING, zoneId, FaultType.NONE);
                     long returnTime = DroneConfig.travelTimeMillis(currentPosition.distanceTo(DroneConfig.BASE_POSITION));
                     Thread.sleep(returnTime / 10);
 
                     // REFILLING
                     currentPosition = DroneConfig.BASE_POSITION;
                     currentAgent = DroneConfig.AGENT_CAPACITY_LITERS;
-                    reportStatus(DroneState.REFILLING, zoneId);
+                    reportStatus(DroneState.REFILLING, zoneId, FaultType.NONE);
                     Thread.sleep(200);
 
                     // IDLE
-                    reportStatus(DroneState.IDLE, null);
+                    reportStatus(DroneState.IDLE, null, FaultType.NONE);
                 }
             } catch (Exception e) {
                 System.err.println("[Drone " + droneId + "] Error: " + e.getMessage());
@@ -93,12 +94,13 @@ public class DroneSubsystem implements Runnable {
         }
     }
 
-    private void reportStatus(DroneState state, Integer zoneId) {
+    private void reportStatus(DroneState state, Integer zoneId, FaultType faultType) {
         try {
             String zoneIdString = (zoneId != null) ? String.valueOf(zoneId) : "0";
-            // Append position so Scheduler knows where each drone is
+            // Append position and fault type so Scheduler knows drone state
             String statusMessage = "STATUS:" + droneId + ":" + state.name() + ":" + zoneIdString
-                    + ":" + currentPosition.x() + ":" + currentPosition.y();
+                    + ":" + currentPosition.x() + ":" + currentPosition.y()
+                    + ":" + faultType.name();
             udp.send(statusMessage, 5000);
 
             if (SimulatorGUI.instance != null) {

--- a/src/main/java/swarm/subsystems/FireIncidentSubsystem.java
+++ b/src/main/java/swarm/subsystems/FireIncidentSubsystem.java
@@ -4,6 +4,7 @@ import swarm.infra.UDPHelper;
 import swarm.main.SimulatorGUI;
 import swarm.messages.DroneStatus;
 import swarm.messages.EventType;
+import swarm.messages.FaultType;
 import swarm.messages.FireEvent;
 import swarm.messages.Severity;
 
@@ -61,8 +62,8 @@ public class FireIncidentSubsystem implements Runnable{
                 // Separate The line into individual parameters
                 String[] parameter = line.split(",");
 
-                // Skip invalid lines
-                if (parameter.length != 4) { continue; }
+                // Skip invalid lines (accept 4 columns or 5 with fault)
+                if (parameter.length < 4 || parameter.length > 5) { continue; }
 
                 try {
 
@@ -77,8 +78,14 @@ public class FireIncidentSubsystem implements Runnable{
                     EventType type = EventType.valueOf(parameter[2].trim());
                     Severity severity = Severity.valueOf(parameter[3].trim().toUpperCase());
 
+                    // Parse fault type; default to NONE if absent
+                    FaultType fault = (parameter.length >= 5)
+                            ? FaultType.valueOf(parameter[4].trim().toUpperCase())
+                            : FaultType.NONE;
+
                     // Serialization and UDP
-                    String message = "FIRE:" + zoneId + ":" + severity.name() + ":" + type.name();
+                    String message = "FIRE:" + zoneId + ":" + severity.name() + ":" + type.name()
+                            + ":" + fault.name();
                     udp.send(message, 5000);
 
                     Thread.sleep(1000);

--- a/src/main/java/swarm/subsystems/Scheduler.java
+++ b/src/main/java/swarm/subsystems/Scheduler.java
@@ -4,6 +4,7 @@ import swarm.infra.UDPHelper;
 import swarm.infra.ZoneManager;
 import swarm.main.SimulatorGUI;
 import swarm.messages.DroneState;
+import swarm.messages.FaultType;
 import swarm.model.Position;
 
 import java.io.IOException;
@@ -90,6 +91,8 @@ public class Scheduler implements Runnable {
                 double posY = Double.parseDouble(parts[5]);
                 dronePositions.put(droneId, new Position(posX, posY));
             }
+
+            FaultType fault = (parts.length >= 5) ? FaultType.valueOf(parts[4]) : FaultType.NONE;
 
             droneStates.put(droneId, state);
 


### PR DESCRIPTION
## Summary
Adds the foundational data model for Iteration 4 fault handling.

## Changes
- Created `FaultType` enum (`NONE`, `DRONE_STUCK`, `NOZZLE_JAMMED`, `PACKET_LOSS`) with `isHardFault()` helper
- Updated `DroneState` to replace generic `FAULT` with `SOFT_FAULT` and `HARD_FAULT`
- Extended `DroneStatus` record with a `FaultType` field (backward-compatible constructor)
- Extended `FireEvent` record with a `FaultType` field (backward-compatible constructor)
- Updated `DroneSubsystem.reportStatus()` to include fault type in STATUS UDP packets
- Updated `FireIncidentSubsystem.readIncidents()` to parse optional 5th CSV column for fault injection
- Updated `Scheduler` to parse fault type from FIRE and STATUS UDP messages
- Extended UDP wire protocol:
  - `STATUS:<droneId>:<state>:<zoneId>:<posX>:<posY>:<faultType>`
  - `FIRE:<zoneId>:<severity>:<eventType>:<faultType>`

Closes #33 